### PR TITLE
Correctly template user-home with lowercased dragon names

### DIFF
--- a/main.py
+++ b/main.py
@@ -632,7 +632,7 @@ def user_dragons():
     owned_dragons = db.session.execute(
         db.select(DragonsOwned).where(DragonsOwned.user_id == user_id)
     ).scalars().all()
-    dragon_names = [d.dragon_obj.name for d in owned_dragons if d.dragon_obj]
+    dragon_names = [d.dragon_obj.name.lower() for d in owned_dragons if d.dragon_obj]
     if dragon_names:
         return render_template("user-dragons.html", dragons=dragon_names)
     else:


### PR DESCRIPTION
Lowercases dragon names fetched from the DB which are passed to the `user-dragons.html` template.
The template will then go look for the `{lowercased_dragon_name}.png` which is how the pngs are stored.

Arguably it's probably better to change the image names so as to avoid an extra operation, even though that operation is just `lower()`